### PR TITLE
fix(test): remove anti-pattern 'it' blocks for verification

### DIFF
--- a/client-spec.js
+++ b/client-spec.js
@@ -200,25 +200,15 @@
 
         it("returns an error message", function (done) {
           //Run the tests
-          client.unfriendMe().then(function() {
-            done(new Error('expected request to /unfriend me to fail'))
-          }, function(e) {
-            expect(e.status).toEqual(404);
-            expect(JSON.parse(e.responseText).error).toEqual('No friends :(')
-            done()
-          })
-
-        });
-
-        // verify with Pact, and reset expectations
-        it('successfully verifies', function(done) {
-          provider.verify()
-            .then(function(a) {
-              done()
+          client.unfriendMe()
+            .then(function() {
+              done(new Error('expected request to /unfriend me to fail'))
             }, function(e) {
-              done.fail(e)
+              expect(e.status).toEqual(404);
+              expect(JSON.parse(e.responseText).error).toEqual('No friends :(')
+              provider.verify().then(done, done.fail)
             })
-        })
+        });
       })
     })
 


### PR DESCRIPTION
Note the `provider.verify().then(done, done.fail)` now embedded into a single 'it' block, this should result in a failed test.

See https://github.com/pact-foundation/pact-js/issues/122 for more commentary.